### PR TITLE
Update Amazon IVS Broadcast/Stages SDK to 1.10.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,5 +2,5 @@ platform :ios, '14.0'
 
 target 'IVS Real-time' do
     pod 'AmazonIVSChat', '~> 1.0.0'
-    pod 'AmazonIVSBroadcast/Stages', '~> 1.9.0'
+    pod 'AmazonIVSBroadcast/Stages', '~> 1.10.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - AmazonIVSBroadcast/Stages (1.9.0)
+  - AmazonIVSBroadcast/Stages (1.10.0)
   - AmazonIVSChat (1.0.0):
     - AmazonIVSChat/Messaging (= 1.0.0)
   - AmazonIVSChat/Messaging (1.0.0)
 
 DEPENDENCIES:
-  - AmazonIVSBroadcast/Stages (~> 1.9.0)
+  - AmazonIVSBroadcast/Stages (~> 1.10.0)
   - AmazonIVSChat (~> 1.0.0)
 
 SPEC REPOS:
@@ -14,9 +14,9 @@ SPEC REPOS:
     - AmazonIVSChat
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: 147e4c70eaa0e26e9de9c93b12d6b117b1aa666f
+  AmazonIVSBroadcast: f9f1de5c3f8470404b5489cee50bbd6e9dc19ee1
   AmazonIVSChat: 62d4e654c4b16b7e62d43048a0e548efd145f183
 
-PODFILE CHECKSUM: c6e67ec1808623ed6bd7ed9caa0c7000b6995888
+PODFILE CHECKSUM: 15cf25055a1f83a2c0374a8ba5057b9b9241efe7
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
- Update Amazon IVS Broadcast/Stages SDK to 1.10.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
