### PR TITLE
Update Amazon IVS Broadcast SDK to 1.12.0

### DIFF
--- a/IVS Real-time/Models/StageModel.swift
+++ b/IVS Real-time/Models/StageModel.swift
@@ -461,7 +461,8 @@ class StageModel: NSObject, ObservableObject {
     }
 
     private func parseBaseData(for stream: IVSStageStream, from stats: [String: [String: String]]) {
-        let candidatePair = stats["candidate-pair"]
+        let selectedCandidatePairId = stats["T01"]?["selectedCandidatePairId"] ?? ""
+        let candidatePair = stats[selectedCandidatePairId]
         let remoteInbound = stats["remote-inbound-rtp"]
         let inbound = stats["inbound-rtp"]
 

--- a/IVS Real-time/Views/Components/DebugDataView.swift
+++ b/IVS Real-time/Views/Components/DebugDataView.swift
@@ -125,7 +125,7 @@ struct AudioListenerDebugDataView: View {
     @StateObject var debugData: DebugData
 
     var body: some View {
-        @State var hostData = debugData.participantStats
+        let hostData = debugData.participantStats
             .filter({ $0.key.contains("audio") })
             .first(where: { $0.value.username == appModel.activeStageHostParticipant?.username })
 

--- a/Podfile
+++ b/Podfile
@@ -2,5 +2,5 @@ platform :ios, '14.0'
 
 target 'IVS Real-time' do
     pod 'AmazonIVSChat', '~> 1.0.0'
-    pod 'AmazonIVSBroadcast/Stages', '~> 1.11.0'
+    pod 'AmazonIVSBroadcast/Stages', '~> 1.12.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - AmazonIVSBroadcast/Stages (1.11.0)
+  - AmazonIVSBroadcast/Stages (1.12.0)
   - AmazonIVSChat (1.0.0):
     - AmazonIVSChat/Messaging (= 1.0.0)
   - AmazonIVSChat/Messaging (1.0.0)
 
 DEPENDENCIES:
-  - AmazonIVSBroadcast/Stages (~> 1.11.0)
+  - AmazonIVSBroadcast/Stages (~> 1.12.0)
   - AmazonIVSChat (~> 1.0.0)
 
 SPEC REPOS:
@@ -14,9 +14,9 @@ SPEC REPOS:
     - AmazonIVSChat
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: d20aaeba4913678b703bcac67992ae3dd34ba08e
+  AmazonIVSBroadcast: ce4f06bc39c6784c2821ea24ec521712a4a39554
   AmazonIVSChat: 62d4e654c4b16b7e62d43048a0e548efd145f183
 
-PODFILE CHECKSUM: b47b29ad8778e03099ce1036e4a8c5b5766b547c
+PODFILE CHECKSUM: e42eb19fa5f901d79cfdee883f31fef86c6e39ce
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Broadcast SDK to 1.12.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
