### PR TITLE
Add video stats on top of preview view

### DIFF
--- a/IVS Real-time.xcodeproj/project.pbxproj
+++ b/IVS Real-time.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		4B92D07D29E8240700DD440D /* DeviceShake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B92D07C29E8240700DD440D /* DeviceShake.swift */; };
 		4B92D07F29E8295000DD440D /* RobotoMono-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4B92D07E29E8295000DD440D /* RobotoMono-Medium.ttf */; };
 		4B92D08129EFB8A600DD440D /* DebugDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B92D08029EFB8A600DD440D /* DebugDataView.swift */; };
+		4BABD0772AB9959800831B32 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BABD0762AB9959800831B32 /* SettingsView.swift */; };
 		4BB7960C29D6EE7A005A4521 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB7960B29D6EE7A005A4521 /* AvatarView.swift */; };
 		4BB7960E29D6F015005A4521 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB7960D29D6F015005A4521 /* UIColor.swift */; };
 		4BB7961029D6FAE2005A4521 /* StageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB7960F29D6FAE2005A4521 /* StageModel.swift */; };
@@ -104,6 +105,7 @@
 		4B92D07C29E8240700DD440D /* DeviceShake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceShake.swift; sourceTree = "<group>"; };
 		4B92D07E29E8295000DD440D /* RobotoMono-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "RobotoMono-Medium.ttf"; sourceTree = "<group>"; };
 		4B92D08029EFB8A600DD440D /* DebugDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDataView.swift; sourceTree = "<group>"; };
+		4BABD0762AB9959800831B32 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4BB7960B29D6EE7A005A4521 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		4BB7960D29D6F015005A4521 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		4BB7960F29D6FAE2005A4521 /* StageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageModel.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				4BB7FD3429D2BB9400E2894D /* IVSRealTimeApp.swift */,
 				4BCC450529D2BFEC003F371E /* WelcomeView.swift */,
 				4BCC450729D2C45E003F371E /* SetupView.swift */,
+				4BABD0762AB9959800831B32 /* SettingsView.swift */,
 				4B10632729D31FAE00242A05 /* FeedsView.swift */,
 				4BCC450429D2BFA5003F371E /* Stages */,
 				4BCC450929D2C4F3003F371E /* Components */,
@@ -462,6 +465,7 @@
 				4B10633629D41CA600242A05 /* PKView.swift in Sources */,
 				4B32DFF229F7FF7000EAA130 /* VoteBarView.swift in Sources */,
 				4B10635729D47F4A00242A05 /* ChatModel.swift in Sources */,
+				4BABD0772AB9959800831B32 /* SettingsView.swift in Sources */,
 				4BB7961829DAF408005A4521 /* ErrorView.swift in Sources */,
 				4BFB13D729D3100E00B9AB5E /* UsernameProvider.swift in Sources */,
 				4B10632A29D3200200242A05 /* VideoStageView.swift in Sources */,

--- a/IVS Real-time/Constants.swift
+++ b/IVS Real-time/Constants.swift
@@ -34,4 +34,5 @@ struct Constants {
     static let kApiKey = "k_api_key"
     static let kMaxBitrate = "k_max_bitrate"
     static let kIsSimulcastOn = "k_is_simulcast_on"
+    static let kIsStatsOn = "k_is_stats_on"
 }

--- a/IVS Real-time/Models/AppModel.swift
+++ b/IVS Real-time/Models/AppModel.swift
@@ -24,6 +24,11 @@ class AppModel: ObservableObject {
             updateVideoConfiguration()
         }
     }
+    @Published var isStatsOn: Bool = true {
+        didSet {
+            UserDefaults.standard.set(isStatsOn, forKey: Constants.kIsStatsOn)
+        }
+    }
 
     @Published var userWantsToJoinVideoStage: Bool = false
     @Published var userWantsToLeaveStage: Bool = false
@@ -93,6 +98,7 @@ class AppModel: ObservableObject {
         self.stageModel = StageModel()
         self.dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         self.isSimulcastOn = UserDefaults.standard.bool(forKey: Constants.kIsSimulcastOn)
+        self.isStatsOn = UserDefaults.standard.bool(forKey: Constants.kIsStatsOn)
 
         username = user.username
         stageModel.localUser = user

--- a/IVS Real-time/Models/AppModel.swift
+++ b/IVS Real-time/Models/AppModel.swift
@@ -97,6 +97,7 @@ class AppModel: ObservableObject {
         self.stagesModel = StagesModel()
         self.stageModel = StageModel()
         self.dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        UserDefaults.standard.register(defaults: [Constants.kIsStatsOn: true])
         self.isSimulcastOn = UserDefaults.standard.bool(forKey: Constants.kIsSimulcastOn)
         self.isStatsOn = UserDefaults.standard.bool(forKey: Constants.kIsStatsOn)
 

--- a/IVS Real-time/Models/Data/User.swift
+++ b/IVS Real-time/Models/Data/User.swift
@@ -29,6 +29,18 @@ class User: ObservableObject {
         return participantId != nil && participantToken != nil
     }
 
+    var videoRequestedAt: Date?
+    var videoReceivedAt: Date? {
+        didSet {
+            if let videoRequestedAt = videoRequestedAt,
+                let diff = videoReceivedAt?.timeIntervalSince(videoRequestedAt) {
+                timeToVideo = "\(Int(diff.rounded())) TTV"
+            }
+        }
+    }
+    @Published var timeToVideo: String?
+    @Published var latency: String?
+
     @Published var isOnStage: Bool = false
     @Published var videoOn: Bool = true
     @Published var audioOn: Bool = true

--- a/IVS Real-time/Models/Data/User.swift
+++ b/IVS Real-time/Models/Data/User.swift
@@ -32,9 +32,9 @@ class User: ObservableObject {
     var videoRequestedAt: Date?
     var videoReceivedAt: Date? {
         didSet {
-            if let videoRequestedAt = videoRequestedAt,
+            if !isLocal, let videoRequestedAt = videoRequestedAt,
                 let diff = videoReceivedAt?.timeIntervalSince(videoRequestedAt) {
-                timeToVideo = "\(Int(diff.rounded())) TTV"
+                timeToVideo = "\(formatter.string(for: Double(diff)) ?? "") TTV"
             }
         }
     }
@@ -86,6 +86,7 @@ class User: ObservableObject {
         return streams.lazy.compactMap { $0.device as? IVSImageDevice }.first
     }
 
+    private let formatter = NumberFormatter()
     private var timer: Timer?
 
     var previewView: StageParticipantView {
@@ -105,6 +106,10 @@ class User: ObservableObject {
         self.hostId = username
         self.isLocal = isLocal
         self.avatar = avatar
+
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 2
+        formatter.decimalSeparator = "."
     }
 
     required init(from decoder: Decoder) throws {

--- a/IVS Real-time/Views/Components/StageParticipantView.swift
+++ b/IVS Real-time/Views/Components/StageParticipantView.swift
@@ -18,13 +18,30 @@ struct StageParticipantView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             if let preview = preview {
-                IVSImagePreviewViewWrapper(previewView: preview)
+                GeometryReader { geometry in
+                    IVSImagePreviewViewWrapper(previewView: preview)
+                        .overlay(alignment: .topTrailing) {
+                            if appModel.isStatsOn {
+                                Text("\(participant.timeToVideo != nil ? "[\(participant.timeToVideo!)]" : "") \(participant.latency != nil ? " [\(participant.latency!)]" : "")")
+                                    .font(Constants.fInterBold14)
+                                    .foregroundColor(.white)
+                                    .shadow(color: .black, radius: 2, x: 1, y: 1)
+                                    .padding(.horizontal, geometry.size.width * 0.05)
+                                    .padding(.top, geometry.size.height * 0.08)
+                                    .onAppear {
+                                        appModel.stageModel.startRTCStats()
+                                    }
+                            }
+                        }
+                        .onAppear {
+                            participant.videoRequestedAt = Date()
+                        }
+                }
             }
 
             if participant.videoMuted || (participant.isLocal && appModel.stageModel.localUserVideoMuted) {
                 ZStack {
                     Color.black
-
                     Image("video-camera-slash")
                         .resizable()
                         .frame(width: 60, height: 60)

--- a/IVS Real-time/Views/Components/StageParticipantView.swift
+++ b/IVS Real-time/Views/Components/StageParticipantView.swift
@@ -28,6 +28,9 @@ struct StageParticipantView: View {
                                     .shadow(color: .black, radius: 2, x: 1, y: 1)
                                     .padding(.horizontal, geometry.size.width * 0.05)
                                     .padding(.top, geometry.size.height * 0.08)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.5)
+                                    .frame(alignment: .trailing)
                                     .onAppear {
                                         appModel.stageModel.startRTCStats()
                                     }

--- a/IVS Real-time/Views/FeedsView.swift
+++ b/IVS Real-time/Views/FeedsView.swift
@@ -222,9 +222,6 @@ struct FeedsView: View {
                 .onAppear {
                     stageModel.startRTCStats()
                 }
-                .onDisappear {
-                    stageModel.endRTCStats()
-                }
             }
         }
     }

--- a/IVS Real-time/Views/SettingsView.swift
+++ b/IVS Real-time/Views/SettingsView.swift
@@ -1,0 +1,81 @@
+//
+//  SettingsView.swift
+//  IVS Real-time
+//
+//  Created by Uldis Zingis on 19/09/2023.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var appModel: AppModel
+    @Binding var isPresent: Bool
+    @State var bitrate: Float = 0
+
+    var body: some View {
+        BottomSheetConfirmationView(
+            isPresent: $isPresent,
+            title: "Settings",
+            contentHeight: 400,
+            dismissTitle: "Dismiss",
+            contentView:
+                VStack {
+                    HStack {
+                        Text("Simulcast")
+                            .font(Constants.fRobotoMonoMedium18)
+                            .foregroundColor(Color("debugViewKeys"))
+                        Spacer()
+                        Toggle(isOn: $appModel.isSimulcastOn) {}
+                            .tint(Color("Orange"))
+                    }
+                    .padding(.bottom, 16)
+
+                    HStack {
+                        Text("Show video stats")
+                            .font(Constants.fRobotoMonoMedium18)
+                            .foregroundColor(Color("debugViewKeys"))
+                        Spacer()
+                        Toggle(isOn: $appModel.isStatsOn) {}
+                            .tint(Color("Orange"))
+                    }
+                    .padding(.bottom, 16)
+
+                    HStack {
+                        Text("Maximum bitrate")
+                            .font(Constants.fRobotoMonoMedium18)
+                            .foregroundColor(Color("debugViewKeys"))
+                        Spacer()
+                        Text("\(Int(bitrate))k")
+                            .font(Constants.fRobotoMonoBold18)
+                            .foregroundColor(appModel.isSimulcastOn ? .gray : .black)
+                    }
+                    UISliderView(value: $bitrate, minValue: 100, maxValue: 900) {
+                        UserDefaults.standard.setValue(Int(bitrate), forKey: Constants.kMaxBitrate)
+                        appModel.updateVideoConfiguration()
+                    }
+                    .disabled(appModel.isSimulcastOn)
+
+                    Rectangle()
+                        .fill(Color("BackgroundGray"))
+                        .frame(height: 1)
+                        .padding(.top, 20)
+                        .padding(.bottom, 30)
+
+                    Button(action: {
+                        withAnimation {
+                            isPresent.toggle()
+                        }
+                        appModel.disconnect()
+                    }) {
+                        Text("Sign out")
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                    }
+                    .modifier(PrimaryButton(color: Color("Red"), textColor: Color.white))
+                }
+        )
+        .onAppear {
+            bitrate = Float(appModel.maxBitrate)
+        }
+    }
+}

--- a/IVS Real-time/Views/SettingsView.swift
+++ b/IVS Real-time/Views/SettingsView.swift
@@ -21,21 +21,21 @@ struct SettingsView: View {
             contentView:
                 VStack {
                     HStack {
-                        Text("Simulcast")
+                        Text("Video stats")
                             .font(Constants.fRobotoMonoMedium18)
                             .foregroundColor(Color("debugViewKeys"))
                         Spacer()
-                        Toggle(isOn: $appModel.isSimulcastOn) {}
+                        Toggle(isOn: $appModel.isStatsOn) {}
                             .tint(Color("Orange"))
                     }
                     .padding(.bottom, 16)
 
                     HStack {
-                        Text("Show video stats")
+                        Text("Simulcast")
                             .font(Constants.fRobotoMonoMedium18)
                             .foregroundColor(Color("debugViewKeys"))
                         Spacer()
-                        Toggle(isOn: $appModel.isStatsOn) {}
+                        Toggle(isOn: $appModel.isSimulcastOn) {}
                             .tint(Color("Orange"))
                     }
                     .padding(.bottom, 16)

--- a/IVS Real-time/Views/SetupView.swift
+++ b/IVS Real-time/Views/SetupView.swift
@@ -11,7 +11,6 @@ struct SetupView: View {
     @EnvironmentObject var appModel: AppModel
     @State var isSettingsPresent: Bool = false
     @State var isStageSelectionPresent: Bool = false
-    @State var bitrate: Float = 0
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -113,60 +112,7 @@ struct SetupView: View {
             .frame(maxHeight: .infinity)
 
             if isSettingsPresent {
-                BottomSheetConfirmationView(
-                    isPresent: $isSettingsPresent,
-                    title: "Settings",
-                    contentHeight: 350,
-                    dismissTitle: "Dismiss",
-                    contentView:
-                        VStack {
-                            HStack {
-                                Text("Simulcast")
-                                    .font(Constants.fRobotoMonoMedium18)
-                                    .foregroundColor(Color("debugViewKeys"))
-                                Spacer()
-                                Toggle(isOn: $appModel.isSimulcastOn) {}
-                                    .tint(Color("Orange"))
-                            }
-                            .padding(.bottom, 16)
-
-                            HStack {
-                                Text("Maximum bitrate")
-                                    .font(Constants.fRobotoMonoMedium18)
-                                    .foregroundColor(Color("debugViewKeys"))
-                                Spacer()
-                                Text("\(Int(bitrate))k")
-                                    .font(Constants.fRobotoMonoBold18)
-                                    .foregroundColor(appModel.isSimulcastOn ? .gray : .black)
-                            }
-                            UISliderView(value: $bitrate, minValue: 100, maxValue: 900) {
-                                UserDefaults.standard.setValue(Int(bitrate), forKey: Constants.kMaxBitrate)
-                                appModel.updateVideoConfiguration()
-                            }
-                            .disabled(appModel.isSimulcastOn)
-
-                            Rectangle()
-                                .fill(Color("BackgroundGray"))
-                                .frame(height: 1)
-                                .padding(.top, 20)
-                                .padding(.bottom, 30)
-
-                            Button(action: {
-                                withAnimation {
-                                    isSettingsPresent.toggle()
-                                }
-                                appModel.disconnect()
-                            }) {
-                                Text("Sign out")
-                                    .frame(maxWidth: .infinity)
-                                    .frame(height: 50)
-                            }
-                            .modifier(PrimaryButton(color: Color("Red"), textColor: Color.white))
-                        }
-                )
-                .onAppear {
-                    bitrate = Float(appModel.maxBitrate)
-                }
+                SettingsView(isPresent: $isSettingsPresent)
             }
 
             if isStageSelectionPresent {


### PR DESCRIPTION
Shows time to video (ttv) in seconds and latency in milliseconds in top right corner, on top of each participant's video.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
